### PR TITLE
docs(public): Comprehensive README overhaul for Muniswap SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,112 @@
-# Uniswap SDK's
+# Muniswap SDKs
 
-A repository for many Uniswap SDK's. All SDK's can be found in `sdk/` and have more information in their individual README's.
+A TypeScript monorepo containing SDK packages for interacting with Uniswap V2, V3, and V4 protocols. Built with modern tooling including native BigInt support and the [ox](https://oxlib.sh/) type-safe RPC library.
+
+## Repository Structure
+
+```
+muniswap-sdks/
+├── packages/           # SDK packages (published to npm)
+│   ├── sdk-core/       # @muniswap/sdk-core - Core entities and utilities
+│   ├── v2-sdk/         # @muniswap/v2-sdk - V2 protocol support
+│   ├── v3-sdk/         # @muniswap/v3-sdk - V3 protocol support
+│   └── v4-sdk/         # @muniswap/v4-sdk - V4 protocol with hooks
+├── apps/               # Application packages (not published)
+│   ├── cli/            # @muniswap/cli - Command-line tools
+│   ├── docs/           # @muniswap/docs - Documentation site (Vocs)
+│   └── ui/             # @muniswap/ui - React UI application
+├── external/           # Git submodule (Uniswap/sdks reference)
+└── publishing/         # Release configuration
+```
+
+The SDK packages form a dependency chain:
+
+```
+sdk-core → v2-sdk → v3-sdk → v4-sdk
+```
+
+## Tech Stack
+
+| Category | Tool |
+|----------|------|
+| Runtime | Node.js >= 20 |
+| Package Manager | pnpm >= 9 |
+| Build Orchestration | Turbo |
+| Bundler | tsup (ESM + CJS dual output) |
+| TypeScript | v5.6+ with strict mode |
+| Testing | Vitest with V8 coverage |
+| Linting/Formatting | Biome |
+| Ethereum Utils | ox |
+
+## Getting Started
+
+```bash
+# Clone (include submodules for reference SDKs)
+git clone --recurse-submodules https://github.com/Jds-23/muniswap-sdks.git
+cd muniswap-sdks
+
+# Install dependencies
+pnpm install
+
+# Build all packages
+pnpm build
+
+# Run all tests
+pnpm test
+```
 
 ## Development Commands
 
-```markdown
-# Clone
-git clone --recurse-submodules https://github.com/Uniswap/sdks.git
-# Install
-yarn
-# Build
-yarn g:build
-# Typecheck
-yarn g:typecheck
-# Lint
-yarn g:lint
-# Test
-yarn g:test
-# Run a specific package.json command for an individual SDK
-yarn sdk @uniswap/{sdk-name} {command}
+```bash
+# Build all packages (uses Turbo caching)
+pnpm build
+
+# Run all tests
+pnpm test
+
+# Type checking
+pnpm typecheck
+
+# Lint all packages
+pnpm lint
+
+# Development mode (watch)
+pnpm dev
+
+# Documentation
+pnpm docs:dev       # Local dev server
+pnpm docs:build     # Build for production
+
+# Clean everything
+pnpm clean
 ```
 
-## Publishing SDK's
+### Per-Package Commands
 
-Publishing of each SDK is done on merge to main using semantic-release and semantic-release-monorepo. PR titles / commits follow angular conventional commits with custom settings that map as follows:
+Run from within any package directory:
 
-```markdown
-- `fix(SDK name):` will trigger a patch version
-- `<type>(public):` will trigger a patch version
-- `feat(SDK name):` will trigger a minor version
-- `feat(breaking):` will trigger a major version for a breaking change
-- `chore(<scope>):` will not trigger a release
+```bash
+pnpm build            # Build the package
+pnpm dev              # Watch mode
+pnpm test             # Run tests
+pnpm test:watch       # Tests in watch mode
+pnpm test:coverage    # Run with coverage report
+pnpm lint             # Check with Biome
+pnpm lint:fix         # Auto-fix lint issues
+pnpm format           # Format code
+pnpm typecheck        # Type check
 ```
 
-Versions will only be generated based on the changelog of the relevant SDK's folder/files.
+## Publishing SDKs
+
+Publishing of each SDK is done on merge to main using semantic-release and semantic-release-monorepo. PR titles and commits follow Angular conventional commits:
+
+| Commit Format | Release |
+|---------------|---------|
+| `fix(<SDK name>):` | Patch version |
+| `<type>(public):` | Patch version |
+| `feat(<SDK name>):` | Minor version |
+| `feat(breaking):` | Major version |
+| `chore(<scope>):` | No release |
+
+Versions are only generated based on the changelog of the relevant SDK's folder/files.


### PR DESCRIPTION
## PR Scope

This is a documentation update following the `docs(public):` convention, which triggers a patch version for non-code changes.

## Description

This PR significantly improves the README.md with comprehensive documentation for the Muniswap SDKs monorepo:

### Changes Made:
- **Rebranded** from "Uniswap SDK's" to "Muniswap SDKs" with updated description
- **Added Repository Structure** section with visual ASCII diagram showing:
  - `packages/` directory with SDK packages (sdk-core, v2-sdk, v3-sdk, v4-sdk)
  - `apps/` directory with application packages (cli, docs, ui)
  - `external/` and `publishing/` directories
  - Dependency chain visualization
- **Added Tech Stack** section with a table documenting:
  - Node.js >= 20
  - pnpm >= 9
  - Turbo, tsup, TypeScript v5.6+
  - Vitest, Biome, ox library
- **Expanded Getting Started** section with:
  - Clone command with submodule support
  - Installation and build instructions
  - Test running commands
- **Reorganized Development Commands** with:
  - Global commands (build, test, typecheck, lint, dev, docs, clean)
  - Per-package commands with descriptions
- **Clarified Publishing SDKs** section with:
  - Conventional commit format table
  - Clear explanation of version triggering rules

### Motivation:
The original README was minimal and didn't adequately document the monorepo structure, tooling, or development workflow. This update provides developers with clear guidance on repository organization, setup, and contribution processes.

## How Has This Been Tested?

Documentation review - no functional code changes to test.

## Are there any breaking changes?

No breaking changes. This is purely documentation.

## (Optional) Follow Ups

- Consider adding contribution guidelines section
- Consider adding troubleshooting section for common setup issues
- Consider adding links to individual package READMEs

https://claude.ai/code/session_017xV3inNPwRrvcJMbQ3qryw